### PR TITLE
Add variable substitution

### DIFF
--- a/sledger.go
+++ b/sledger.go
@@ -143,11 +143,6 @@ func loadSledgerYaml(path string) sledger {
 
 	replaceVariables(&sledger)
 
-	for _, value := range sledger.Sledger {
-		fmt.Printf("Forward = %v", value.Forward)
-		fmt.Printf("Backward = %v", value.Backward)
-	}
-
 	return sledger
 }
 
@@ -212,7 +207,7 @@ func sync(db *sql.DB, sledger sledger) {
 				os.Exit(1)
 			}
 
-			fmt.Printf("SKIP      %s\n", yamlForward)
+			fmt.Printf("SKIP      %s\n", AbbreviateSqlCommand(yamlForward))
 		}
 
 		index++
@@ -229,12 +224,21 @@ func sync(db *sql.DB, sledger sledger) {
 	}
 }
 
+func AbbreviateSqlCommand(cmd string) string {
+	idx := strings.IndexAny(cmd, " ")
+	if idx > 0 {
+		return cmd[:idx]
+	} else {
+		return cmd
+	}
+}
+
 func doRollback(db *sql.DB, index int, dbBackward string) {
 	if dbBackward == "" {
 		fmt.Println("ERROR     Missing rollback command, cannot rollback.")
 		os.Exit(1)
 	} else {
-		fmt.Printf("ROLLBACK  %s\n", dbBackward)
+		fmt.Printf("ROLLBACK  %s\n", AbbreviateSqlCommand(dbBackward))
 
 		tx, err := db.Begin()
 		if err != nil {
@@ -261,7 +265,7 @@ func doRollback(db *sql.DB, index int, dbBackward string) {
 }
 
 func doForward(db *sql.DB, index int, yamlForward string, yamlBackward string) {
-	fmt.Printf("FORWARD   %s\n", yamlForward)
+	fmt.Printf("FORWARD   %s\n", AbbreviateSqlCommand(yamlForward))
 
 	tx, err := db.Begin()
 	if err != nil {

--- a/sledger.go
+++ b/sledger.go
@@ -26,6 +26,7 @@ type (
 	}
 )
 
+// This is done for testing purposes
 var (
 	OSGetenv = os.Getenv
 )
@@ -146,6 +147,7 @@ func loadSledgerYaml(path string) sledger {
 	return sledger
 }
 
+// Replaces all variables in Forward and Backward sql statements of sledger.
 func replaceVariables(sledger *sledger) {
 	fmt.Println("\t...replacing env vars")
 
@@ -156,6 +158,9 @@ func replaceVariables(sledger *sledger) {
 	}
 }
 
+// This function takes a string and replaces all ${VARIABLES} with their corresponding environment variable value.
+// This function also does minimal checking (eg: if there is a '${' there must be a closing '}').  If there is no
+// environment variable set for a defined ${VARIABLE}, then a panic occurs.
 func ReplaceVariablesInString(in string) string {
 	index := strings.IndexAny(in, "${")
 	for index != -1 {
@@ -224,6 +229,8 @@ func sync(db *sql.DB, sledger sledger) {
 	}
 }
 
+// This function abbreviates an sql command down to it's first instruction (which is usually meaningful).  This is
+// primarily done to prevent leaking credentials to stdout.
 func AbbreviateSqlCommand(cmd string) string {
 	idx := strings.IndexAny(cmd, " ")
 	if idx > 0 {

--- a/sledger_test.go
+++ b/sledger_test.go
@@ -10,6 +10,7 @@ var (
 	MockOSGetenvParameters []map[string]string
 )
 
+// Test the case where there are no variable substitutions in the string
 func TestReplaceVariablesInStringNoReplacements(t *testing.T) {
 	sqlStatement := "REVOKE ALL ON SCHEMA public FROM PUBLIC"
 	result := ReplaceVariablesInString(sqlStatement)
@@ -18,6 +19,7 @@ func TestReplaceVariablesInStringNoReplacements(t *testing.T) {
 	}
 }
 
+// Test the case where there is one variable substitution in the string
 func TestReplaceVariablesInStringOneReplacement(t *testing.T) {
 	setupMocks()
 
@@ -39,6 +41,7 @@ func TestReplaceVariablesInStringOneReplacement(t *testing.T) {
 	}
 }
 
+// Test the case where there are multiple variable substitutions in the string
 func TestReplaceVariablesInStringTwoReplacements(t *testing.T) {
 	setupMocks()
 
@@ -62,6 +65,7 @@ func TestReplaceVariablesInStringTwoReplacements(t *testing.T) {
 	}
 }
 
+// Sets up and/or resets mocks
 func setupMocks() {
 	OSGetenv = mockOSGetenv
 	MockOSGetenvCounter = 0
@@ -69,6 +73,7 @@ func setupMocks() {
 	MockOSGetenvParameters = []map[string]string{}
 }
 
+// Mock function for os.Getenv
 func mockOSGetenv(key string) string {
 	MockOSGetenvCounter += 1
 

--- a/sledger_test.go
+++ b/sledger_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+)
+
+var (
+	MockOSGetenvCounter    = 0
+	MockOSGetenvResult     []string
+	MockOSGetenvParameters []map[string]string
+)
+
+func TestReplaceVariablesInStringNoReplacements(t *testing.T) {
+	sqlStatement := "REVOKE ALL ON SCHEMA public FROM PUBLIC"
+	result := ReplaceVariablesInString(sqlStatement)
+	if sqlStatement != result {
+		t.Fatalf(`ReplaceVariablesInString("%v") = %v, want match for %v`, sqlStatement, result, sqlStatement)
+	}
+}
+
+func TestReplaceVariablesInStringOneReplacement(t *testing.T) {
+	setupMocks()
+
+	sqlStatement := "CREATE ROLE some_user WITH LOGIN ENCRYPTED PASSWORD '${PASSWORD}'"
+	want := "CREATE ROLE some_user WITH LOGIN ENCRYPTED PASSWORD 'abc123'"
+
+	OSGetenv = mockOSGetenv
+	MockOSGetenvResult = []string{"abc123"}
+
+	result := ReplaceVariablesInString(sqlStatement)
+	if want != result {
+		t.Fatalf(`ReplaceVariablesInString("%v") = %v, want match for %v`, sqlStatement, result, sqlStatement)
+	}
+	if MockOSGetenvParameters[0]["key"] != "PASSWORD" {
+		t.Fatalf(`Expected parameter to OSGetEnv: %v, instead received %v`, "PASSWORD", MockOSGetenvParameters[0]["key"])
+	}
+	if MockOSGetenvCounter != 1 {
+		t.Fatalf(`Expected OSGetEnv function to be called 1 time`)
+	}
+}
+
+func TestReplaceVariablesInStringTwoReplacements(t *testing.T) {
+	setupMocks()
+
+	sqlStatement := "CREATE ROLE ${USER} WITH LOGIN ENCRYPTED PASSWORD '${PASSWORD}'"
+	want := "CREATE ROLE some_user WITH LOGIN ENCRYPTED PASSWORD 'abc123'"
+
+	MockOSGetenvResult = []string{"some_user", "abc123"}
+
+	result := ReplaceVariablesInString(sqlStatement)
+	if want != result {
+		t.Fatalf(`ReplaceVariablesInString("%v") = %v, want match for %v`, sqlStatement, result, sqlStatement)
+	}
+	if MockOSGetenvParameters[1]["key"] != "PASSWORD" {
+		t.Fatalf(`Expected parameter to OSGetEnv: %v, instead received %v`, "PASSWORD", MockOSGetenvParameters[0]["key"])
+	}
+	if MockOSGetenvParameters[0]["key"] != "USER" {
+		t.Fatalf(`Expected parameter to OSGetEnv: %v, instead received %v`, "USER", MockOSGetenvParameters[0]["key"])
+	}
+	if MockOSGetenvCounter != 2 {
+		t.Fatalf(`Expected OSGetEnv function to be called 2 times`)
+	}
+}
+
+func setupMocks() {
+	OSGetenv = mockOSGetenv
+	MockOSGetenvCounter = 0
+	MockOSGetenvResult = []string{}
+	MockOSGetenvParameters = []map[string]string{}
+}
+
+func mockOSGetenv(key string) string {
+	MockOSGetenvCounter += 1
+
+	MockOSGetenvParameters = append(MockOSGetenvParameters, map[string]string{"key": key})
+
+	return MockOSGetenvResult[MockOSGetenvCounter-1]
+}


### PR DESCRIPTION
This PR adds the ability to perform variable substitution within the forward/backward sql statements.  You would want to do this when specifying a password in the ledger.  You would want that password to be passed in as an environment variable and then substituted into the sql.

In total, I did the following:
* Added functionality for variable substitution
* Added some unit tests for the parts I added
* Modified/abbreviated  existing printout statements to remove the possibility of leaking credentials to stdout while still having them be meaningful

Happy to make any changes you may suggest - this is my first legit golang experience.